### PR TITLE
add GitHub action to automatically build artifacts on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+    release:
+        types: [published]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Extract tag version number
+              id: get_version
+              uses: battila7/get-version-action@v2
+
+            - name: Substitute version in manifest
+              uses: microsoft/variable-substitution@v1
+              with:
+                  files: 'system.json'
+              env:
+                  version: ${{steps.get_version.outputs.version-without-v}}
+                  manifest: https://github.com/${{github.repository}}/releases/download/{{$github.event.release.tag_name}}/system.json
+                  download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/candelafvtt-v${{steps.get_version.outputs.version-without-v}}.zip
+
+            - name: Install dependencies and build
+              run: |
+                  npm install -g yarn
+                  npm ci
+                  sh build.sh
+
+            - name: Update release with files
+              uses: ncipollo/release-action@v1
+              with:
+                  allowUpdates: true
+                  name: ${{ github.event.release.name }}
+                  draft: false
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  artifacts: './system.json, ./dist/candelafvtt-v${{steps.get_version.outputs.version-without-v}}.zip'
+                  tag: ${{ github.event.release.tag_name }}
+                  body: ${{ github.event.release.body }}


### PR DESCRIPTION
This GitHub action will run each time a new release is created on the repository and will build and upload the generated artifacts directly to the release.

### Note

For this action to work you need to go to this repository Settings > Actions > General and change Workflow permissions at the bottom to "Read and write permissions" so the action has permissions to upload the artifacts to the release.

<img width="952" alt="Screenshot 2023-11-29 at 18 54 27" src="https://github.com/ceriath/candelafvtt/assets/1312023/7717bfa5-f9aa-4944-aa11-503946666a61">
