### PR TITLE
Move cricle gear to cirle gear folder and add their descriptions

### DIFF
--- a/packs/src/gear/Bleed_Containment_Vial_SFxyEFmlP1MxosXV.json
+++ b/packs/src/gear/Bleed_Containment_Vial_SFxyEFmlP1MxosXV.json
@@ -1,11 +1,11 @@
 {
-  "folder": "eMq1spqAtgBgSeEC",
+  "folder": "yU9fHXAti9gx9tDe",
   "name": "Bleed Containment Vial",
   "type": "Gear",
   "_id": "SFxyEFmlP1MxosXV",
   "img": "icons/svg/item-bag.svg",
   "system": {
-    "description": ""
+    "description": "<p>A small container that can hold the remnants of magickal phenomena.</p>"
   },
   "effects": [],
   "sort": 0,

--- a/packs/src/gear/Bleed_Detector_g6IB0pT2LtADN348.json
+++ b/packs/src/gear/Bleed_Detector_g6IB0pT2LtADN348.json
@@ -1,11 +1,11 @@
 {
-  "folder": "eMq1spqAtgBgSeEC",
+  "folder": "yU9fHXAti9gx9tDe",
   "name": "Bleed Detector",
   "type": "Gear",
   "_id": "g6IB0pT2LtADN348",
   "img": "icons/svg/item-bag.svg",
   "system": {
-    "description": ""
+    "description": "<p>A small flashlight, a spyglass, a music box, or other mechanism that allows investigators to perceive the evidence of phenomena. </p>"
   },
   "effects": [],
   "sort": 0,

--- a/packs/src/gear/Hand_Weapon_JM5DVCi5a1n3WoM4.json
+++ b/packs/src/gear/Hand_Weapon_JM5DVCi5a1n3WoM4.json
@@ -1,11 +1,11 @@
 {
-  "folder": "eMq1spqAtgBgSeEC",
+  "folder": "yU9fHXAti9gx9tDe",
   "name": "Hand Weapon",
   "type": "Gear",
   "_id": "JM5DVCi5a1n3WoM4",
   "img": "icons/svg/item-bag.svg",
   "system": {
-    "description": ""
+    "description": "<p>A handgun, knife, brass knuckles, or other dangerous item that's easily concealed.</p>"
   },
   "effects": [],
   "sort": 0,


### PR DESCRIPTION
## Motivation

Currently, all gear, including Circle gear, is in the "Investigator Gear" folder.

## Changes

- Moved `Bleed Containment Vial`, `Bleed Detector`, and `Hand Weapon` to the `Circle gear` folder
- Added descriptions to the circle gear items

## Visual QA

<img width="710" alt="Screenshot 2024-01-14 114551" src="https://github.com/ceriath/candelafvtt/assets/1135003/8984bb37-1cf0-4e7a-9137-ce8bd4e37386">
