### PR TITLE
Add Illumination keys

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ then
     echo "version number required, e.g. ./build.sh 1.0.0"
     exit 1
 fi
-rm -rf packs/abilities/ packs/gear/ packs/manual/ packs/roles/ packs/specialties/
+rm -rf packs/abilities/ packs/gear/ packs/manual/ packs/roles/ packs/specialties/ packs/illumination-keys/
 rm -rf dist/
 rm -rf css/
 mkdir dist

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,6 +41,7 @@ async function packAll() {
     await fvtt.compilePack('packs/src/roles', 'packs/roles');
     await fvtt.compilePack('packs/src/gear', 'packs/gear');
     await fvtt.compilePack('packs/src/manual', 'packs/manual');
+    await fvtt.compilePack('packs/src/illumination-key', 'packs/illumination-key');
 }
 
 async function unpackAll() {
@@ -51,6 +52,7 @@ async function unpackAll() {
     await fvtt.extractPack('packs/roles', 'packs/src/roles');
     await fvtt.extractPack('packs/gear', 'packs/src/gear');
     await fvtt.extractPack('packs/manual', 'packs/src/manual');
+    await fvtt.extractPack('packs/illumination-keys', 'packs/src/illumination-keys');
 }
 
 /* ----------------------------------------- */

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,7 +41,7 @@ async function packAll() {
     await fvtt.compilePack('packs/src/roles', 'packs/roles');
     await fvtt.compilePack('packs/src/gear', 'packs/gear');
     await fvtt.compilePack('packs/src/manual', 'packs/manual');
-    await fvtt.compilePack('packs/src/illumination-key', 'packs/illumination-key');
+    await fvtt.compilePack('packs/src/illumination-keys', 'packs/illumination-keys');
 }
 
 async function unpackAll() {

--- a/lang/en.json
+++ b/lang/en.json
@@ -46,6 +46,7 @@
     "CANDELAFVTT.catalyst": "Catalyst",
     "CANDELAFVTT.question": "Question",
     "CANDELAFVTT.background": "Background",
+    "CANDELAFVTT.illuminationKeys": "Illumination Keys",
 
     "CANDELAFVTT.abilities-description": "Choose one at character creation and one each time your circle advances.",
     "CANDELAFVTT.illumination-description": "When the Illumination track is full, clear the track. Any leftover Illumination counts toward your next advancement cycle. Then choose a new circle ability, and all players can choose their character advancement options. The red circles represent milestones, which may have mechanical benefits depending on what abilities your circle chooses.",

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -17,4 +17,5 @@ CANDELAFVTT.types = {
     gear: 'Gear',
     role: 'Role',
     specialty: 'Specialty',
+    illuminationKey: 'IlluminationKey',
 };

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -12,5 +12,6 @@ export const preloadHandlebarsTemplates = async function () {
         'systems/candelafvtt/templates/actor/parts/actor-actions.hbs',
         'systems/candelafvtt/templates/actor/parts/actor-biography.hbs',
         'systems/candelafvtt/templates/actor/parts/actor-members.hbs',
+        'systems/candelafvtt/templates/actor/parts/actor-illumination-keys.hbs',
     ]);
 };

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -119,6 +119,7 @@ export class CandelafvttActorSheet extends ActorSheet {
         // Initialize containers.
         const gear = [];
         const abilities = [];
+        const illuminationKeys = [];
 
         // Iterate through items, allocating to containers
         for (let i of context.items) {
@@ -130,11 +131,15 @@ export class CandelafvttActorSheet extends ActorSheet {
             else if (i.type === CONFIG.CANDELAFVTT.types.ability) {
                 abilities.push(i);
             }
+            else if (i.type === CONFIG.CANDELAFVTT.types.illuminationKey) {
+                illuminationKeys.push(i);
+            }
         }
 
         // Assign and return
         context.gear = gear;
         context.abilities = abilities;
+        context.illuminationKeys = illuminationKeys;
     }
 
     /* -------------------------------------------- */

--- a/packs/src/illumination-keys/Act_Bizarre_2SnBcD4vgy1eH7DI.json
+++ b/packs/src/illumination-keys/Act_Bizarre_2SnBcD4vgy1eH7DI.json
@@ -1,0 +1,26 @@
+{
+  "folder": "QauwrkpN8cVgHVGO",
+  "name": "Act Bizarre",
+  "type": "IlluminationKey",
+  "_id": "2SnBcD4vgy1eH7DI",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185267205,
+    "modifiedTime": 1705185267205,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!2SnBcD4vgy1eH7DI"
+}

--- a/packs/src/illumination-keys/Act_Tactically_RGmpAKc1mPuWTsOV.json
+++ b/packs/src/illumination-keys/Act_Tactically_RGmpAKc1mPuWTsOV.json
@@ -1,0 +1,26 @@
+{
+  "folder": "14cxmuahEG1PHyVk",
+  "name": "Act Tactically",
+  "type": "IlluminationKey",
+  "_id": "RGmpAKc1mPuWTsOV",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185102790,
+    "modifiedTime": 1705185102790,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!RGmpAKc1mPuWTsOV"
+}

--- a/packs/src/illumination-keys/Aid_an_Ally_sOYBwyyoKUYGM7Ld.json
+++ b/packs/src/illumination-keys/Aid_an_Ally_sOYBwyyoKUYGM7Ld.json
@@ -1,0 +1,26 @@
+{
+  "folder": "pl0cHdkcCE1sIczc",
+  "name": "Aid an Ally",
+  "type": "IlluminationKey",
+  "_id": "sOYBwyyoKUYGM7Ld",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185119555,
+    "modifiedTime": 1705185119555,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!sOYBwyyoKUYGM7Ld"
+}

--- a/packs/src/illumination-keys/Avoid_a_Fight_DsdVdEcSWVlcDRWd.json
+++ b/packs/src/illumination-keys/Avoid_a_Fight_DsdVdEcSWVlcDRWd.json
@@ -1,0 +1,26 @@
+{
+  "folder": "pl0cHdkcCE1sIczc",
+  "name": "Avoid a Fight",
+  "type": "IlluminationKey",
+  "_id": "DsdVdEcSWVlcDRWd",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185112886,
+    "modifiedTime": 1705185112886,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!DsdVdEcSWVlcDRWd"
+}

--- a/packs/src/illumination-keys/Collect_Oddities_MGPdiCKrFUCtjMSL.json
+++ b/packs/src/illumination-keys/Collect_Oddities_MGPdiCKrFUCtjMSL.json
@@ -1,0 +1,26 @@
+{
+  "folder": "QauwrkpN8cVgHVGO",
+  "name": "Collect Oddities",
+  "type": "IlluminationKey",
+  "_id": "MGPdiCKrFUCtjMSL",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185260374,
+    "modifiedTime": 1705185260374,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!MGPdiCKrFUCtjMSL"
+}

--- a/packs/src/illumination-keys/Comfort_Someone_CKfvQowBv871ToZi.json
+++ b/packs/src/illumination-keys/Comfort_Someone_CKfvQowBv871ToZi.json
@@ -1,0 +1,26 @@
+{
+  "folder": "pl0cHdkcCE1sIczc",
+  "name": "Comfort Someone",
+  "type": "IlluminationKey",
+  "_id": "CKfvQowBv871ToZi",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185129965,
+    "modifiedTime": 1705185129965,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!CKfvQowBv871ToZi"
+}

--- a/packs/src/illumination-keys/Connect_with_Someone_NMuTDFynrbpdnZZB.json
+++ b/packs/src/illumination-keys/Connect_with_Someone_NMuTDFynrbpdnZZB.json
@@ -1,0 +1,26 @@
+{
+  "folder": "BGIay6gbo6Tkaukq",
+  "name": "Connect with Someone",
+  "type": "IlluminationKey",
+  "_id": "NMuTDFynrbpdnZZB",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185215971,
+    "modifiedTime": 1705185215971,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!NMuTDFynrbpdnZZB"
+}

--- a/packs/src/illumination-keys/Consult_Arcane_Texts_KvDpHT9DGxYQkcRi.json
+++ b/packs/src/illumination-keys/Consult_Arcane_Texts_KvDpHT9DGxYQkcRi.json
@@ -1,0 +1,26 @@
+{
+  "folder": "QauwrkpN8cVgHVGO",
+  "name": "Consult Arcane Texts",
+  "type": "IlluminationKey",
+  "_id": "KvDpHT9DGxYQkcRi",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185242577,
+    "modifiedTime": 1705185242577,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!KvDpHT9DGxYQkcRi"
+}

--- a/packs/src/illumination-keys/Criminal_xZhXrPn3xxJSB9qr.json
+++ b/packs/src/illumination-keys/Criminal_xZhXrPn3xxJSB9qr.json
@@ -1,0 +1,19 @@
+{
+  "name": "Criminal",
+  "sorting": "a",
+  "folder": "lvup5wRFwGSQS3Pv",
+  "type": "Item",
+  "_id": "xZhXrPn3xxJSB9qr",
+  "sort": null,
+  "color": null,
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185015097,
+    "modifiedTime": 1706970469453,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!folders!xZhXrPn3xxJSB9qr"
+}

--- a/packs/src/illumination-keys/Detective_NV9ZQial1GS5No3A.json
+++ b/packs/src/illumination-keys/Detective_NV9ZQial1GS5No3A.json
@@ -1,0 +1,19 @@
+{
+  "name": "Detective",
+  "sorting": "a",
+  "folder": "lvup5wRFwGSQS3Pv",
+  "type": "Item",
+  "_id": "NV9ZQial1GS5No3A",
+  "sort": 0,
+  "color": null,
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185029718,
+    "modifiedTime": 1706970469453,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!folders!NV9ZQial1GS5No3A"
+}

--- a/packs/src/illumination-keys/Discuss_History_GLs8unKfFGmOAK4o.json
+++ b/packs/src/illumination-keys/Discuss_History_GLs8unKfFGmOAK4o.json
@@ -1,0 +1,26 @@
+{
+  "folder": "a8ffmH3E5ytK24M1",
+  "name": "Discuss History",
+  "type": "IlluminationKey",
+  "_id": "GLs8unKfFGmOAK4o",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185068131,
+    "modifiedTime": 1705185068131,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!GLs8unKfFGmOAK4o"
+}

--- a/packs/src/illumination-keys/Do_Something_Illegal_RCdHzrLhA32mZbff.json
+++ b/packs/src/illumination-keys/Do_Something_Illegal_RCdHzrLhA32mZbff.json
@@ -1,0 +1,26 @@
+{
+  "folder": "xZhXrPn3xxJSB9qr",
+  "name": "Do Something Illegal",
+  "type": "IlluminationKey",
+  "_id": "RCdHzrLhA32mZbff",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185170889,
+    "modifiedTime": 1705185170889,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!RCdHzrLhA32mZbff"
+}

--- a/packs/src/illumination-keys/Doctor_pl0cHdkcCE1sIczc.json
+++ b/packs/src/illumination-keys/Doctor_pl0cHdkcCE1sIczc.json
@@ -1,0 +1,19 @@
+{
+  "name": "Doctor",
+  "sorting": "a",
+  "folder": "PpECaxCofC2uTe2r",
+  "type": "Item",
+  "_id": "pl0cHdkcCE1sIczc",
+  "sort": 0,
+  "color": "#807ee2",
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705184998741,
+    "modifiedTime": 1706970469453,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!folders!pl0cHdkcCE1sIczc"
+}

--- a/packs/src/illumination-keys/Explorer_a8ffmH3E5ytK24M1.json
+++ b/packs/src/illumination-keys/Explorer_a8ffmH3E5ytK24M1.json
@@ -1,0 +1,19 @@
+{
+  "name": "Explorer",
+  "sorting": "a",
+  "folder": "8CK73bdhLj1LQu6s",
+  "type": "Item",
+  "_id": "a8ffmH3E5ytK24M1",
+  "sort": 0,
+  "color": "#df7272",
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705184989681,
+    "modifiedTime": 1706970469453,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!folders!a8ffmH3E5ytK24M1"
+}

--- a/packs/src/illumination-keys/Face_fAElPjfqnPRSkm9d.json
+++ b/packs/src/illumination-keys/Face_fAElPjfqnPRSkm9d.json
@@ -1,0 +1,19 @@
+{
+  "name": "Face",
+  "sorting": "a",
+  "folder": null,
+  "type": "Item",
+  "_id": "fAElPjfqnPRSkm9d",
+  "sort": 0,
+  "color": "#55a5a4",
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1706970284571,
+    "modifiedTime": 1706970469453,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!folders!fAElPjfqnPRSkm9d"
+}

--- a/packs/src/illumination-keys/Gather_Statements_Cxd5PDFqyMkUYieY.json
+++ b/packs/src/illumination-keys/Gather_Statements_Cxd5PDFqyMkUYieY.json
@@ -1,0 +1,26 @@
+{
+  "name": "Gather Statements",
+  "type": "IlluminationKey",
+  "_id": "Cxd5PDFqyMkUYieY",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "folder": "6Ro3s1yWRxFMGQjO",
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705184117818,
+    "modifiedTime": 1705184187035,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!Cxd5PDFqyMkUYieY"
+}

--- a/packs/src/illumination-keys/Hunt_Down_a_Lead_Yw1ywZXjnof5PAbQ.json
+++ b/packs/src/illumination-keys/Hunt_Down_a_Lead_Yw1ywZXjnof5PAbQ.json
@@ -1,0 +1,26 @@
+{
+  "name": "Hunt Down a Lead",
+  "type": "IlluminationKey",
+  "_id": "Yw1ywZXjnof5PAbQ",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "folder": "6Ro3s1yWRxFMGQjO",
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705184177084,
+    "modifiedTime": 1705184188238,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!Yw1ywZXjnof5PAbQ"
+}

--- a/packs/src/illumination-keys/Journalist_6Ro3s1yWRxFMGQjO.json
+++ b/packs/src/illumination-keys/Journalist_6Ro3s1yWRxFMGQjO.json
@@ -1,0 +1,19 @@
+{
+  "name": "Journalist",
+  "sorting": "a",
+  "folder": "fAElPjfqnPRSkm9d",
+  "type": "Item",
+  "_id": "6Ro3s1yWRxFMGQjO",
+  "sort": 0,
+  "color": "#3dae97",
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705183450284,
+    "modifiedTime": 1706970469453,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!folders!6Ro3s1yWRxFMGQjO"
+}

--- a/packs/src/illumination-keys/Magician_UlhFfbdBMRIYpdgK.json
+++ b/packs/src/illumination-keys/Magician_UlhFfbdBMRIYpdgK.json
@@ -1,0 +1,19 @@
+{
+  "name": "Magician",
+  "sorting": "a",
+  "folder": "fAElPjfqnPRSkm9d",
+  "type": "Item",
+  "_id": "UlhFfbdBMRIYpdgK",
+  "sort": 0,
+  "color": "#3dae97",
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705184196306,
+    "modifiedTime": 1706970469453,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!folders!UlhFfbdBMRIYpdgK"
+}

--- a/packs/src/illumination-keys/Make_a_Deal_eF4SS4AwJXG5cjVU.json
+++ b/packs/src/illumination-keys/Make_a_Deal_eF4SS4AwJXG5cjVU.json
@@ -1,0 +1,26 @@
+{
+  "folder": "xZhXrPn3xxJSB9qr",
+  "name": "Make a Deal",
+  "type": "IlluminationKey",
+  "_id": "eF4SS4AwJXG5cjVU",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185179829,
+    "modifiedTime": 1705185179829,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!eF4SS4AwJXG5cjVU"
+}

--- a/packs/src/illumination-keys/Make_a_Plan_nA16WOcdKl7RRha1.json
+++ b/packs/src/illumination-keys/Make_a_Plan_nA16WOcdKl7RRha1.json
@@ -1,0 +1,26 @@
+{
+  "folder": "KrYqeLki86Wf12Id",
+  "name": "Make a Plan",
+  "type": "IlluminationKey",
+  "_id": "nA16WOcdKl7RRha1",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185158812,
+    "modifiedTime": 1705185158812,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!nA16WOcdKl7RRha1"
+}

--- a/packs/src/illumination-keys/Make_a_Scene_kQV6GMxbXkWOJoTl.json
+++ b/packs/src/illumination-keys/Make_a_Scene_kQV6GMxbXkWOJoTl.json
@@ -1,0 +1,26 @@
+{
+  "folder": "BGIay6gbo6Tkaukq",
+  "name": "Make a Scene",
+  "type": "IlluminationKey",
+  "_id": "kQV6GMxbXkWOJoTl",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185232778,
+    "modifiedTime": 1705185232778,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!kQV6GMxbXkWOJoTl"
+}

--- a/packs/src/illumination-keys/Medium_BGIay6gbo6Tkaukq.json
+++ b/packs/src/illumination-keys/Medium_BGIay6gbo6Tkaukq.json
@@ -1,0 +1,19 @@
+{
+  "name": "Medium",
+  "sorting": "a",
+  "folder": "IK8e5DeK48CPpkBL",
+  "type": "Item",
+  "_id": "BGIay6gbo6Tkaukq",
+  "sort": 0,
+  "color": "#0b5c05",
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185033007,
+    "modifiedTime": 1706970488828,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!folders!BGIay6gbo6Tkaukq"
+}

--- a/packs/src/illumination-keys/Mentor_an_Ally_VD0H8iuRUO0O7Mdo.json
+++ b/packs/src/illumination-keys/Mentor_an_Ally_VD0H8iuRUO0O7Mdo.json
@@ -1,0 +1,26 @@
+{
+  "folder": "KrYqeLki86Wf12Id",
+  "name": "Mentor an Ally",
+  "type": "IlluminationKey",
+  "_id": "VD0H8iuRUO0O7Mdo",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185145488,
+    "modifiedTime": 1705185145488,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!VD0H8iuRUO0O7Mdo"
+}

--- a/packs/src/illumination-keys/Muscle_8CK73bdhLj1LQu6s.json
+++ b/packs/src/illumination-keys/Muscle_8CK73bdhLj1LQu6s.json
@@ -1,0 +1,19 @@
+{
+  "name": "Muscle",
+  "sorting": "a",
+  "folder": null,
+  "type": "Item",
+  "_id": "8CK73bdhLj1LQu6s",
+  "sort": 0,
+  "color": "#af3131",
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1706970427914,
+    "modifiedTime": 1706970469453,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!folders!8CK73bdhLj1LQu6s"
+}

--- a/packs/src/illumination-keys/Occultist_QauwrkpN8cVgHVGO.json
+++ b/packs/src/illumination-keys/Occultist_QauwrkpN8cVgHVGO.json
@@ -1,0 +1,19 @@
+{
+  "name": "Occultist",
+  "sorting": "a",
+  "folder": "IK8e5DeK48CPpkBL",
+  "type": "Item",
+  "_id": "QauwrkpN8cVgHVGO",
+  "sort": 0,
+  "color": "#0b5c05",
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185036285,
+    "modifiedTime": 1706970495356,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!folders!QauwrkpN8cVgHVGO"
+}

--- a/packs/src/illumination-keys/Perform_a_Trick_wk7POD6RJROgVPcb.json
+++ b/packs/src/illumination-keys/Perform_a_Trick_wk7POD6RJROgVPcb.json
@@ -1,0 +1,26 @@
+{
+  "folder": "UlhFfbdBMRIYpdgK",
+  "name": "Perform a Trick",
+  "type": "IlluminationKey",
+  "_id": "wk7POD6RJROgVPcb",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705184207259,
+    "modifiedTime": 1705184207259,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!wk7POD6RJROgVPcb"
+}

--- a/packs/src/illumination-keys/Probe_a_Witness_7iz6WHq4hOSFExgy.json
+++ b/packs/src/illumination-keys/Probe_a_Witness_7iz6WHq4hOSFExgy.json
@@ -1,0 +1,26 @@
+{
+  "folder": "NV9ZQial1GS5No3A",
+  "name": "Probe a Witness",
+  "type": "IlluminationKey",
+  "_id": "7iz6WHq4hOSFExgy",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185194951,
+    "modifiedTime": 1705185194951,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!7iz6WHq4hOSFExgy"
+}

--- a/packs/src/illumination-keys/Professor_KrYqeLki86Wf12Id.json
+++ b/packs/src/illumination-keys/Professor_KrYqeLki86Wf12Id.json
@@ -1,0 +1,19 @@
+{
+  "name": "Professor",
+  "sorting": "a",
+  "folder": "PpECaxCofC2uTe2r",
+  "type": "Item",
+  "_id": "KrYqeLki86Wf12Id",
+  "sort": 0,
+  "color": "#807ee2",
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185009867,
+    "modifiedTime": 1706970469453,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!folders!KrYqeLki86Wf12Id"
+}

--- a/packs/src/illumination-keys/Protect_Someone_gdNqimYOjhVhgqqj.json
+++ b/packs/src/illumination-keys/Protect_Someone_gdNqimYOjhVhgqqj.json
@@ -1,0 +1,26 @@
+{
+  "folder": "14cxmuahEG1PHyVk",
+  "name": "Protect Someone",
+  "type": "IlluminationKey",
+  "_id": "gdNqimYOjhVhgqqj",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185095935,
+    "modifiedTime": 1705185095935,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!gdNqimYOjhVhgqqj"
+}

--- a/packs/src/illumination-keys/Reference_Research_ZUKCPLxz0gbCaZSg.json
+++ b/packs/src/illumination-keys/Reference_Research_ZUKCPLxz0gbCaZSg.json
@@ -1,0 +1,26 @@
+{
+  "folder": "KrYqeLki86Wf12Id",
+  "name": "Reference Research",
+  "type": "IlluminationKey",
+  "_id": "ZUKCPLxz0gbCaZSg",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185151778,
+    "modifiedTime": 1705185151778,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!ZUKCPLxz0gbCaZSg"
+}

--- a/packs/src/illumination-keys/Reveal_a_Clue_TJ1GWsZ85NycFaom.json
+++ b/packs/src/illumination-keys/Reveal_a_Clue_TJ1GWsZ85NycFaom.json
@@ -1,0 +1,26 @@
+{
+  "folder": "NV9ZQial1GS5No3A",
+  "name": "Reveal a Clue",
+  "type": "IlluminationKey",
+  "_id": "TJ1GWsZ85NycFaom",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185207767,
+    "modifiedTime": 1705185207767,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!TJ1GWsZ85NycFaom"
+}

--- a/packs/src/illumination-keys/Run_into_Danger_LtsNxc80ZJCPHO3D.json
+++ b/packs/src/illumination-keys/Run_into_Danger_LtsNxc80ZJCPHO3D.json
@@ -1,0 +1,27 @@
+{
+  "folder": "a8ffmH3E5ytK24M1",
+  "name": "Run into Danger",
+  "type": "IlluminationKey",
+  "_id": "LtsNxc80ZJCPHO3D",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": "",
+    "subtype": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185075805,
+    "modifiedTime": 1705185075805,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!LtsNxc80ZJCPHO3D"
+}

--- a/packs/src/illumination-keys/Scholar_PpECaxCofC2uTe2r.json
+++ b/packs/src/illumination-keys/Scholar_PpECaxCofC2uTe2r.json
@@ -1,0 +1,19 @@
+{
+  "name": "Scholar",
+  "sorting": "a",
+  "folder": null,
+  "type": "Item",
+  "_id": "PpECaxCofC2uTe2r",
+  "sort": 0,
+  "color": "#4b4fb9",
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1706970445173,
+    "modifiedTime": 1706970469453,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!folders!PpECaxCofC2uTe2r"
+}

--- a/packs/src/illumination-keys/Seek_Out_Real_Magick_OuFweaWRN5Yx8G47.json
+++ b/packs/src/illumination-keys/Seek_Out_Real_Magick_OuFweaWRN5Yx8G47.json
@@ -1,0 +1,27 @@
+{
+  "folder": "UlhFfbdBMRIYpdgK",
+  "name": "Seek Out Real Magick",
+  "type": "IlluminationKey",
+  "_id": "OuFweaWRN5Yx8G47",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": "",
+    "subtype": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705184225327,
+    "modifiedTime": 1705184225327,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!OuFweaWRN5Yx8G47"
+}

--- a/packs/src/illumination-keys/Sense_Phenomena_sRGvcVPYsC47IeHa.json
+++ b/packs/src/illumination-keys/Sense_Phenomena_sRGvcVPYsC47IeHa.json
@@ -1,0 +1,27 @@
+{
+  "folder": "BGIay6gbo6Tkaukq",
+  "name": "Sense Phenomena",
+  "type": "IlluminationKey",
+  "_id": "sRGvcVPYsC47IeHa",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": "",
+    "subtype": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185224334,
+    "modifiedTime": 1705185224334,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!sRGvcVPYsC47IeHa"
+}

--- a/packs/src/illumination-keys/Slink_lvup5wRFwGSQS3Pv.json
+++ b/packs/src/illumination-keys/Slink_lvup5wRFwGSQS3Pv.json
@@ -1,0 +1,19 @@
+{
+  "name": "Slink",
+  "sorting": "a",
+  "folder": null,
+  "type": "Item",
+  "_id": "lvup5wRFwGSQS3Pv",
+  "sort": 0,
+  "color": "#4a4a4a",
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1706970455915,
+    "modifiedTime": 1706970469453,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!folders!lvup5wRFwGSQS3Pv"
+}

--- a/packs/src/illumination-keys/Soldier_14cxmuahEG1PHyVk.json
+++ b/packs/src/illumination-keys/Soldier_14cxmuahEG1PHyVk.json
@@ -1,0 +1,19 @@
+{
+  "name": "Soldier",
+  "sorting": "a",
+  "folder": "8CK73bdhLj1LQu6s",
+  "type": "Item",
+  "_id": "14cxmuahEG1PHyVk",
+  "sort": 0,
+  "color": "#df7272",
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705184995604,
+    "modifiedTime": 1706970469453,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!folders!14cxmuahEG1PHyVk"
+}

--- a/packs/src/illumination-keys/Speak_Truth_to_Power_YqGq7NeKIOtUznP7.json
+++ b/packs/src/illumination-keys/Speak_Truth_to_Power_YqGq7NeKIOtUznP7.json
@@ -1,0 +1,27 @@
+{
+  "folder": "6Ro3s1yWRxFMGQjO",
+  "name": "Speak Truth to Power",
+  "type": "IlluminationKey",
+  "_id": "YqGq7NeKIOtUznP7",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": "",
+    "subtype": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705184185311,
+    "modifiedTime": 1705184185311,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!YqGq7NeKIOtUznP7"
+}

--- a/packs/src/illumination-keys/Spot_a_Ruse_mJD7uwqEHIJZP61K.json
+++ b/packs/src/illumination-keys/Spot_a_Ruse_mJD7uwqEHIJZP61K.json
@@ -1,0 +1,27 @@
+{
+  "folder": "UlhFfbdBMRIYpdgK",
+  "name": "Spot a Ruse",
+  "type": "IlluminationKey",
+  "_id": "mJD7uwqEHIJZP61K",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": "",
+    "subtype": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705184218526,
+    "modifiedTime": 1705184218526,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!mJD7uwqEHIJZP61K"
+}

--- a/packs/src/illumination-keys/Stand_Up_to_Authority_Uk3Si2o1OPqs1itA.json
+++ b/packs/src/illumination-keys/Stand_Up_to_Authority_Uk3Si2o1OPqs1itA.json
@@ -1,0 +1,27 @@
+{
+  "folder": "xZhXrPn3xxJSB9qr",
+  "name": "Stand Up to Authority",
+  "type": "IlluminationKey",
+  "_id": "Uk3Si2o1OPqs1itA",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": "",
+    "subtype": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185187417,
+    "modifiedTime": 1705185187417,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!Uk3Si2o1OPqs1itA"
+}

--- a/packs/src/illumination-keys/Study_an_Artifact_OW1c2Uyz9KPOK0U0.json
+++ b/packs/src/illumination-keys/Study_an_Artifact_OW1c2Uyz9KPOK0U0.json
@@ -1,0 +1,27 @@
+{
+  "folder": "a8ffmH3E5ytK24M1",
+  "name": "Study an Artifact",
+  "type": "IlluminationKey",
+  "_id": "OW1c2Uyz9KPOK0U0",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": "",
+    "subtype": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185060368,
+    "modifiedTime": 1705185060368,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!OW1c2Uyz9KPOK0U0"
+}

--- a/packs/src/illumination-keys/Track_a_Target_FNEYQEQif33Jpkay.json
+++ b/packs/src/illumination-keys/Track_a_Target_FNEYQEQif33Jpkay.json
@@ -1,0 +1,27 @@
+{
+  "folder": "NV9ZQial1GS5No3A",
+  "name": "Track a Target",
+  "type": "IlluminationKey",
+  "_id": "FNEYQEQif33Jpkay",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": "",
+    "subtype": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185201378,
+    "modifiedTime": 1705185201378,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!FNEYQEQif33Jpkay"
+}

--- a/packs/src/illumination-keys/Use_Violence_of_Action_nv9JkLlRWqLFQlIN.json
+++ b/packs/src/illumination-keys/Use_Violence_of_Action_nv9JkLlRWqLFQlIN.json
@@ -1,0 +1,27 @@
+{
+  "folder": "14cxmuahEG1PHyVk",
+  "name": "Use Violence of Action",
+  "type": "IlluminationKey",
+  "_id": "nv9JkLlRWqLFQlIN",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": "",
+    "subtype": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mm1zGnUd8T7aHRjq": 3
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1705185088561,
+    "modifiedTime": 1705185088561,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!items!nv9JkLlRWqLFQlIN"
+}

--- a/packs/src/illumination-keys/Weird_IK8e5DeK48CPpkBL.json
+++ b/packs/src/illumination-keys/Weird_IK8e5DeK48CPpkBL.json
@@ -1,0 +1,19 @@
+{
+  "name": "Weird",
+  "sorting": "a",
+  "folder": null,
+  "type": "Item",
+  "_id": "IK8e5DeK48CPpkBL",
+  "sort": 0,
+  "color": "#487237",
+  "flags": {},
+  "_stats": {
+    "systemId": "candelafvtt",
+    "systemVersion": "0.0.4",
+    "coreVersion": "11.315",
+    "createdTime": 1706970465171,
+    "modifiedTime": 1706970469453,
+    "lastModifiedBy": "mm1zGnUd8T7aHRjq"
+  },
+  "_key": "!folders!IK8e5DeK48CPpkBL"
+}

--- a/scss/components/_items.scss
+++ b/scss/components/_items.scss
@@ -59,7 +59,7 @@
   // Control Buttons
   .item-controls {
     display: flex;
-    flex: 0 0 100px;
+    flex: 0 0 auto;
     justify-content: flex-end;
     a {
       font-size: 12px;

--- a/system.json
+++ b/system.json
@@ -51,6 +51,15 @@
       "flags": {}
     },
     {
+      "name": "illumination-keys",
+      "label": "Illumination Keys",
+      "system": "candelafvtt",
+      "path": "packs/illumination-keys",
+      "type": "Item",
+      "private": false,
+      "flags": {}
+    },
+    {
       "name": "manual",
       "label": "System Manual",
       "system": "candelafvtt",

--- a/template.json
+++ b/template.json
@@ -162,7 +162,8 @@
       "Ability",
       "Gear",
       "Role",
-      "Specialty"
+      "Specialty",
+      "IlluminationKey"
     ],
     "templates": {
       "base": {
@@ -215,6 +216,11 @@
           "sense": 0
         }
       }
+    },
+    "IlluminationKey": {
+      "templates": [
+        "base"
+      ]
     }
   }
 }

--- a/templates/actor/parts/actor-biography.hbs
+++ b/templates/actor/parts/actor-biography.hbs
@@ -4,6 +4,7 @@
     <a class='item' data-tab='bio-style'>{{localize 'CANDELAFVTT.style'}}</a>
     <a class='item' data-tab='bio-catalyst'>{{localize 'CANDELAFVTT.catalyst'}}</a>
     <a class='item' data-tab='bio-question'>{{localize 'CANDELAFVTT.question'}}</a>
+    <a class='item' data-tab='bio-illuminationKeys'>{{localize 'CANDELAFVTT.illuminationKeys'}}</a>
 </nav>
 
 <section class='bio-body'>
@@ -22,6 +23,9 @@
     </div>
     <div class='tab biography' data-group='primary' data-tab='bio-question'>
         {{editor system.question target='system.question' rollData=rollData button=true owner=owner editable=editable engine='prosemirror' class='prosemirror-editor'}}
+    </div>
+    <div class='tab biography' data-group='primary' data-tab='bio-illuminationKeys'>
+        {{> 'systems/candelafvtt/templates/actor/parts/actor-illumination-keys.hbs' }}
     </div>
 
 </section>

--- a/templates/actor/parts/actor-illumination-keys.hbs
+++ b/templates/actor/parts/actor-illumination-keys.hbs
@@ -1,0 +1,22 @@
+<ol class='items-list'>
+    <li class='item flexrow items-header align-right'>
+        <div class='item-controls'>
+            <a class='item-control item-create' title='Create Illumination Key' data-type='IlluminationKey'><i
+                    class='fas fa-plus'></i>Add Illumination Key</a>
+        </div>
+    </li>
+    {{#each illuminationKeys as |illuminationKey id|}}
+    <li class='item flexrow' data-item-id='{{illuminationKey._id}}'>
+        <div class='item-name'>
+            <div class='item-image'>
+                <img src='{{illuminationKey.img}}' title='{{illuminationKey.name}}' width='24' height='24' />
+            </div>
+            <h4>{{illuminationKey.name}}</h4>
+        </div>
+        <div class='item-controls'>
+            <a class='item-control item-edit' title='Edit Item'><i class='fas fa-edit'></i></a>
+            <a class='item-control item-delete' title='Delete Item'><i class='fas fa-trash'></i></a>
+        </div>
+    </li>
+    {{/each}}
+</ol>

--- a/templates/actor/parts/actor-illumination-keys.hbs
+++ b/templates/actor/parts/actor-illumination-keys.hbs
@@ -1,8 +1,9 @@
 <ol class='items-list'>
     <li class='item flexrow items-header align-right'>
         <div class='item-controls'>
-            <a class='item-control item-create' title='Create Illumination Key' data-type='IlluminationKey'><i
-                    class='fas fa-plus'></i>Add Illumination Key</a>
+            <a class='item-control item-create' title='Create Illumination Key' data-type='IlluminationKey'>
+                <i class='fas fa-plus'></i> Add Illumination Key
+            </a>
         </div>
     </li>
     {{#each illuminationKeys as |illuminationKey id|}}

--- a/templates/item/item-illuminationkey-sheet.hbs
+++ b/templates/item/item-illuminationkey-sheet.hbs
@@ -1,0 +1,21 @@
+<form class='{{cssClass}}' autocomplete='off'>
+    <header class='sheet-header'>
+        <img class='profile-img' src='{{item.img}}' data-edit='img' title='{{item.name}}' />
+        <div class='header-fields'>
+            <h1 class='charname'><input name='name' type='text' value='{{item.name}}' placeholder='Name' /></h1>
+        </div>
+    </header>
+
+    {{! Sheet Tab Navigation }}
+    <nav class='sheet-tabs tabs' data-group='primary'>
+        <a class='item' data-tab='description'>Description</a>
+    </nav>
+
+    {{! Sheet Body }}
+    <section class='sheet-body'>
+        {{! Description Tab }}
+        <div class='tab' data-group='primary' data-tab='description'>
+            {{editor system.description target='system.description' rollData=rollData button=true owner=owner editable=editable engine='prosemirror'}}
+        </div>
+    </section>
+</form>


### PR DESCRIPTION
## Motivation

Currently, the system lacks the concept of Illumination keys. The goal of this PR is to address this by introducing Illumination keys to the system. The idea is to implement the bare minimum to unlock this feature for users and lay the groundwork for possible future iterations (e.g., automatic assignment of illumination keys from specialties).

Resolves ceriath/candelafvtt#8

## Changes

- Added "IlluminationKey" as a new item type
- Added "Illumination keys" pack
- Added "Illumination keys" to the character sheet (under "Biography" -  see [this comment](https://github.com/ceriath/candelafvtt/issues/8#issuecomment-1925327753) for my reasoning)

## Out of scope

- Automatic assignment of illumination keys from specialties (see [this comment](https://github.com/ceriath/candelafvtt/issues/8#issuecomment-1925325070) for my reasoning).
- Adding DE and ES translations for the newly added "Illumination keys" tab (I'll leave it to native speakers).

## Visual QA

<img width="1073" alt="illumination_keys" src="https://github.com/ceriath/candelafvtt/assets/1135003/5be096c1-5fd3-4232-95ba-c5df409a1458">