### PR TITLE
Add gilded dice option for rolls

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -53,6 +53,8 @@
 
     "CANDELAFVTT.driveBonus": "Add drives",
     "CANDELAFVTT.driveBonusDescription": "Add additional drives from yourself or your fellow investigators",
+    "CANDELAFVTT.gildedDiceBonus": "Add gilded dice",
+    "CANDELAFVTT.gildedDiceDescription": "Add additional gilded dice, for example from Stamina Training",
     "CANDELAFVTT.roll": "Test your luck!",
 
     "CANDELAFVTT.errors-invalid-spec": "The selected specialty is invalid for your selected role!"

--- a/module/documents/action.mjs
+++ b/module/documents/action.mjs
@@ -12,7 +12,7 @@ export class Action {
         if (result == null) return; // dialog canceled
         const [drives, extraGildedDice] = result
 
-        const actionGilded = action.gilded ? (action.value > 0 ? 1 : 0) : 0
+        const actionGilded = (action.gilded && action.value > 0) ? 1 : 0
         const normalDice = action.value - actionGilded + drives
         const gildedDice = actionGilded + extraGildedDice
         var dice = []

--- a/module/documents/action.mjs
+++ b/module/documents/action.mjs
@@ -13,6 +13,7 @@ export class Action {
         const [drives, extraGildedDice] = result
 
         const actionGilded = action.gilded ? 1 : 0
+        const actionGilded = action.gilded ? (action.value > 0 ? 1 : 0) : 0
         const normalDice = action.value - actionGilded + drives
         const gildedDice = actionGilded + extraGildedDice
         var dice = []

--- a/module/documents/action.mjs
+++ b/module/documents/action.mjs
@@ -12,7 +12,6 @@ export class Action {
         if (result == null) return; // dialog canceled
         const [drives, extraGildedDice] = result
 
-        const actionGilded = action.gilded ? 1 : 0
         const actionGilded = action.gilded ? (action.value > 0 ? 1 : 0) : 0
         const normalDice = action.value - actionGilded + drives
         const gildedDice = actionGilded + extraGildedDice

--- a/templates/chat/roll-dialog.hbs
+++ b/templates/chat/roll-dialog.hbs
@@ -6,4 +6,11 @@
         </div>
         <input type='text' name='drives' value='0' data-dtype='Number' placeholder='0' />
     </div>
+    <div class='form-group roll-dialog'>
+        <div class='roll-label'>
+            <label>{{localize 'CANDELAFVTT.gildedDiceBonus'}}</label>
+            <div class='description'>{{localize 'CANDELAFVTT.gildedDiceDescription'}}</div>
+        </div>
+        <input type='text' name='gildedDice' value='0' data-dtype='Number' placeholder='0' />
+    </div>
 </form>


### PR DESCRIPTION
Add the ability to specify additional gilded dice for a roll.

Clean up roll logic a bit.

I think for rolls with only normal dice, we were adding all the dice results together instead of using the highest. That is now fixed.

Do I need to add entries for the other supported languages? —It looks like it will fall back on English if entries for the other languages aren't present, which is what we want.

I've tested this with my own local copy of Foundry.

Test steps:
1. Bring up an action roll alert. Verify that the new option appears below the existing one, saying "Add gilded dice" "Additional gilded dice, for example from Stamina Training" <img width="431" alt="Modified Alert" src="https://github.com/user-attachments/assets/9a07d226-ece0-466c-b39f-8a0bd7117447" />
2. Verify that closing alert does not trigger the roll
3. Verify that rolling for an action with no rating, and no added drives or gilded dice, correctly rolls with disadvantage
4. Verify that rolling for an action with no rating, and with an added drive, rolls with 1 normal die. Same for adding two drives, rolls with 2 normal dice
5. Verify that rolling for an action with no rating, and with an added gilded die, rolls with 1 gilded die. Same for adding two gilded dice, rolls with 2 gilded dice
6. Verify that rolling an action with one rating but no gilded setting rolls 1 normal die
7. Verify that rolling an action with one rating and the gilded setting rolls 1 gilded die
8. Verify further combinations of gilded setting, action ratings, and added drives and gilded dice results in the correct number and kind of dice being rolled