### PR TITLE
Update action names

### DIFF
--- a/module/documents/action.mjs
+++ b/module/documents/action.mjs
@@ -48,7 +48,7 @@ export class Action {
         // construct chat message
         const speaker = ChatMessage.getSpeaker({ actor: this.actor });
         const rollMode = game.settings.get('core', 'rollMode');
-        const label = `[action] ${actionId}`;
+        const label = `[action] ` + game.i18n.localize(`CANDELAFVTT.${actionId}`);
         const content = await renderTemplate('systems/candelafvtt/templates/chat/roll.hbs', r);
 
         const msg = {
@@ -73,7 +73,7 @@ export class Action {
      * @private
      */
     static async _prepareActionRoll(actionId) {
-        let title = actionId;
+        let title = game.i18n.localize(`CANDELAFVTT.${actionId}`);
         let content = await renderTemplate('systems/candelafvtt/templates/chat/roll-dialog.hbs');
         let options = {};
 


### PR DESCRIPTION
Update some action names to use the localized versions of the name, rather than the English action ID.

Not trying to be exhaustive with these changes, just want to see how it feels.

Screenshot of one of the places changed, the title of the dialog for the roll:
<img width="509" alt="Screenshot 2024-12-31 at 1 27 54 PM" src="https://github.com/user-attachments/assets/7c79eeac-280b-4b1c-8059-7dcedb8edfe5" />

Screenshot of the other place that was changed, the name of the entry in Chat Messages:
<img width="311" alt="Screenshot 2024-12-31 at 1 28 14 PM" src="https://github.com/user-attachments/assets/26e0e364-07f2-4aed-8343-fc308d775e16" />
