### PR TITLE
Restyle chat messages

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -72,6 +72,13 @@
     "CANDELAFVTT.gildedDiceDescription": "Add additional gilded dice, for example from Stamina Training",
     "CANDELAFVTT.roll": "Test your luck!",
 
-    "CANDELAFVTT.errors-invalid-spec": "The selected specialty is invalid for your selected role!"
-
+    "CANDELAFVTT.errors-invalid-spec": "The selected specialty is invalid for your selected role!",
+    
+    "CANDELAFVTT.oneDieRollFlavorLabel": "1 Die",
+    "CANDELAFVTT.multipleDiceRollFlavorLabel": "Best of {number} Dice",
+    "CANDELAFVTT.oneGildedDieRollFlavorLabel": "1 Gilded Die",
+    "CANDELAFVTT.multipleGildedDiceRollFlavorLabel": "Best of {number} Gilded Dice",
+    "CANDELAFVTT.noDiceRollFlavorLabel": "No Dice (Take Lower)",
+    "CANDELAFVTT.noDiceNormalDieRollFlavorLabel": "No Dice (Take Lower)",
+    "CANDELAFVTT.noDiceGildedDieRollFlavorLabel": "No Dice, Gilded (Take Lower)"
 }

--- a/module/documents/action.mjs
+++ b/module/documents/action.mjs
@@ -22,6 +22,7 @@ export class Action {
             const die = new Die({
                 number: normalDice,
                 faces: 6,
+                options: { flavor: normalDice == 1 ? game.i18n.localize(`CANDELAFVTT.oneDieRollFlavorLabel`) : game.i18n.format(`CANDELAFVTT.multipleDiceRollFlavorLabel`, {number: normalDice})},
                 modifiers: ['kh'],
             });
             dice = [die]
@@ -31,7 +32,7 @@ export class Action {
             const die = new Die({
                 number: gildedDice,
                 faces: 6,
-                options: { flavor: 'gilded' },
+                options: { flavor: gildedDice == 1 ? game.i18n.localize(`CANDELAFVTT.oneGildedDieRollFlavorLabel`) : game.i18n.format(`CANDELAFVTT.multipleGildedDiceRollFlavorLabel`, {number: gildedDice})},
                 modifiers: ['kh'],
             });
             if (dice.length > 0) {
@@ -42,13 +43,32 @@ export class Action {
         }
 
         if (!dice.length) {
-            // no dice, roll with disadvantage
-            const die = new Die({
-                number: 2,
-                faces: 6,
-                modifiers: ['kl'],
-            });
-            dice = [die]
+            if (action.gilded) {
+                // no dice, but still roll one gilded die, one regular die (yes, this is in the rules)
+                const gildedDie = new Die({
+                    number: 1,
+                    faces: 6,
+                    options: { flavor: game.i18n.localize(`CANDELAFVTT.noDiceGildedDieRollFlavorLabel`) }
+                });
+                dice = [gildedDie]
+                const plus = new OperatorTerm({ operator: '+' });
+                dice.push(plus)
+                const die = new Die({
+                    number: 1,
+                    faces: 6,
+                    options: { flavor: game.i18n.localize(`CANDELAFVTT.noDiceNormalDieRollFlavorLabel`) }
+                });
+                dice.push(die)
+            } else {
+                // no dice, roll with disadvantage
+                const die = new Die({
+                    number: 2,
+                    faces: 6,
+                    options: { flavor: game.i18n.localize(`CANDELAFVTT.noDiceRollFlavorLabel`) },
+                    modifiers: ['kl'],
+                });
+                dice = [die]
+            }
         }
 
         let r = Roll.fromTerms(dice);

--- a/templates/chat/roll.hbs
+++ b/templates/chat/roll.hbs
@@ -1,13 +1,11 @@
 <div class='candelafvtt dice-roll'>
     <div class='dice-result'>
-        <div class='dice-formula'>{{formula}}</div>
         <div class='dice-tooltip expanded'>
             {{#each dice as |die|}}
                 <section class='tooltip-part'>
                     <div class='dice'>
                         <header class='part-header flexrow'>
-                            <span class='part-formula'>{{die.formula}}</span>
-                            {{#if die.flavor}}<span class='part-flavor'>{{die.flavor}}</span>{{/if}}
+                            <span class='part-formula'>{{die.flavor}}</span>
                             <span class='part-total'>{{die.total}}</span>
                         </header>
                         <ol class='dice-rolls'>


### PR DESCRIPTION
Use flavor to provide full English text for roll messages.

Is that the best way to do it? Are there better ways to do it?

Is there better text to use? I want to keep things consistent, intelligible, and short.

Note the functionality to properly show a no-dice gilded roll is new.

Here are examples of how it will look:

<img width="311" alt="Screenshot 1" src="https://github.com/user-attachments/assets/acce4b16-f728-4a7b-b6d3-ecd2b388a4bb" />

<img width="311" alt="Screenshot 2" src="https://github.com/user-attachments/assets/ca38baf9-ed49-49bd-a415-e71fe6381392" />

<img width="322" alt="Screenshot 3" src="https://github.com/user-attachments/assets/83c57db7-710d-4685-b69b-736de8169521" />
